### PR TITLE
Fix a pointer freed inside `unsafe` block in BlockingTask

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -66,18 +66,19 @@ impl BlockingTask {
         );
 
         match unsafe {
-            let ctx = self.ctx.map(|v| v.as_ptr());
+            let ctx_copy = self.ctx.as_ref().map(|v| pyo3::ffi::PyContext_Copy(v.as_ptr()));
             let callable = self.target.into_ptr();
             let args = self.args.into_ptr();
-            if let Some(ctx) = ctx {
-                pyo3::ffi::PyContext_Enter(ctx);
+            if let Some(cctx) = ctx_copy {
+                pyo3::ffi::PyContext_Enter(cctx);
             }
             let ret = match self.kwargs {
                 Some(kw) => pyo3::ffi::PyObject_Call(callable, args, kw.into_ptr()),
                 None => pyo3::ffi::PyObject_CallObject(callable, args),
             };
-            if let Some(ctx) = ctx {
-                pyo3::ffi::PyContext_Exit(ctx);
+            if let Some(cctx) = ctx_copy {
+                pyo3::ffi::PyContext_Exit(cctx);
+                pyo3::ffi::Py_DECREF(cctx);
             }
             Bound::from_owned_ptr_or_err(py, ret)
         } {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,6 +1,7 @@
 use crossbeam_channel as channel;
 use pyo3::{PyTypeInfo, prelude::*};
 use std::{
+    ptr::NonNull,
     sync::{Arc, atomic},
     thread, time,
 };
@@ -66,19 +67,22 @@ impl BlockingTask {
         );
 
         match unsafe {
-            let ctx_copy = self.ctx.as_ref().map(|v| pyo3::ffi::PyContext_Copy(v.as_ptr()));
+            let ctx_copy = self
+                .ctx
+                .as_ref()
+                .and_then(|v| NonNull::new(pyo3::ffi::PyContext_Copy(v.as_ptr())));
             let callable = self.target.into_ptr();
             let args = self.args.into_ptr();
             if let Some(cctx) = ctx_copy {
-                pyo3::ffi::PyContext_Enter(cctx);
+                pyo3::ffi::PyContext_Enter(cctx.as_ptr());
             }
             let ret = match self.kwargs {
                 Some(kw) => pyo3::ffi::PyObject_Call(callable, args, kw.into_ptr()),
                 None => pyo3::ffi::PyObject_CallObject(callable, args),
             };
             if let Some(cctx) = ctx_copy {
-                pyo3::ffi::PyContext_Exit(cctx);
-                pyo3::ffi::Py_DECREF(cctx);
+                pyo3::ffi::PyContext_Exit(cctx.as_ptr());
+                pyo3::ffi::Py_DECREF(cctx.as_ptr());
             }
             Bound::from_owned_ptr_or_err(py, ret)
         } {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,7 +1,6 @@
 use crossbeam_channel as channel;
 use pyo3::{PyTypeInfo, prelude::*};
 use std::{
-    ptr::NonNull,
     sync::{Arc, atomic},
     thread, time,
 };
@@ -67,22 +66,18 @@ impl BlockingTask {
         );
 
         match unsafe {
-            let ctx_copy = self
-                .ctx
-                .as_ref()
-                .and_then(|v| NonNull::new(pyo3::ffi::PyContext_Copy(v.as_ptr())));
+            let ctx = self.ctx.as_ref().map(|v| v.as_ptr());
             let callable = self.target.into_ptr();
             let args = self.args.into_ptr();
-            if let Some(cctx) = ctx_copy {
-                pyo3::ffi::PyContext_Enter(cctx.as_ptr());
+            if let Some(ctx) = ctx {
+                pyo3::ffi::PyContext_Enter(ctx);
             }
             let ret = match self.kwargs {
                 Some(kw) => pyo3::ffi::PyObject_Call(callable, args, kw.into_ptr()),
                 None => pyo3::ffi::PyObject_CallObject(callable, args),
             };
-            if let Some(cctx) = ctx_copy {
-                pyo3::ffi::PyContext_Exit(cctx.as_ptr());
-                pyo3::ffi::Py_DECREF(cctx.as_ptr());
+            if let Some(ctx) = ctx {
+                pyo3::ffi::PyContext_Exit(ctx);
             }
             Bound::from_owned_ptr_or_err(py, ret)
         } {

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -78,3 +78,16 @@ def test_block_on(run):
 
     run(_run())
     assert set(stack) == {1, 2}
+
+
+def test_block_on_multiple_times(run):
+    def _noop():
+        yield
+
+    def _blocking(_):
+        tonio.block_on(_noop())
+
+    def _run():
+        yield tonio.map_blocking(_blocking, range(100))
+
+    run(_run())

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -78,16 +78,3 @@ def test_block_on(run):
 
     run(_run())
     assert set(stack) == {1, 2}
-
-
-def test_block_on_multiple_times(run):
-    def _noop():
-        yield
-
-    def _blocking(_):
-        tonio.block_on(_noop())
-
-    def _run():
-        yield tonio.map_blocking(_blocking, range(100))
-
-    run(_run())


### PR DESCRIPTION
~`PyContext_Enter/Exit` require a per-thread copy of the context when called from a worker thread.~

The contextvar handling is consuming a pointer inside an unsafe block. It _usually_ works, until this piece of memory got used for something else.

Found this when trying to bake an `asyncio`-based backend to add support for Windows.

The way I got to reproduce the issue is to stress the problematic part fast and enough times to make the freed memory be reused. 