### PR TITLE
[FIX] Runtime can hang when a scope is canceled with sleep inside

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -85,6 +85,8 @@ impl Runtime {
                 if timer.when > tick {
                     let dt = (timer.when - tick) as u64;
                     sched_time = Some(dt);
+                } else {
+                    sched_time = Some(0);
                 }
             }
         }

--- a/tests/colored/test_colored_scope.py
+++ b/tests/colored/test_colored_scope.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import tonio.colored as tonio
 
 
@@ -45,3 +49,31 @@ def test_scope_cancel_immediate(run):
 
     assert set(enter) == {1}
     assert not exit
+
+
+def test_scope_cancel_pending_sleep_hangs_not():
+    # Run in a subprocess as a failure hangs forever
+    script = textwrap.dedent("""
+        import tonio
+        from tonio import colored
+
+        runtime = tonio.runtime(threads=4, blocking_threadpool_size=8, blocking_threadpool_idle_ttl=10, context=True)
+
+        async def _run():
+            async with colored.scope() as scope:
+                for i in range(50):
+                    scope.spawn(colored.sleep(0.01))
+                await colored.yield_now()
+                scope.cancel()
+            await colored.sleep(0.3)
+
+        runtime.run_pyasyncgen_until_complete(_run())
+        print('OK')
+    """)
+
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, '-c', script], capture_output=True, text=True, timeout=5.0
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert 'OK' in proc.stdout


### PR DESCRIPTION
When a scope cancels a sleep(), its Timer is left still pending. It may be "processed" before `tick`. If this happens, the `sched_time` cannot be let as None.

The runtime will only "unblock" if another deferred in the future wakes the runtime. Otherwise the runtime will be blocked forever.

Found that also during the Windows' asyncio-based backend development.

Without the `else { sched_time = Some(0) }`, the test raises a TimeoutExpired
